### PR TITLE
feat: add Ifeval rule

### DIFF
--- a/CheDocs/Ifeval.yml
+++ b/CheDocs/Ifeval.yml
@@ -1,0 +1,7 @@
+---
+extends: existence
+level: warning
+message: "Consider using an AsciiDoc attribute for inline content or an example for block content, rather than an 'ifeval' directive."
+scope: raw
+raw:
+  - 'ifeval\:\:\['

--- a/fixtures/CheDocs/Ifeval/.vale.ini
+++ b/fixtures/CheDocs/Ifeval/.vale.ini
@@ -1,0 +1,5 @@
+; Vale configuration file to test the `Ifeval` rule
+StylesPath = ../../..
+MinAlertLevel = suggestion
+[*.adoc]
+CheDocs.Ifeval = YES

--- a/fixtures/CheDocs/Ifeval/testinvalid.adoc
+++ b/fixtures/CheDocs/Ifeval/testinvalid.adoc
@@ -1,0 +1,3 @@
+ifeval::["{project-context}" == "che"]
+Something
+endif::[]


### PR DESCRIPTION
message: "Consider using an AsciiDoc attribute for inline content or an example for block content, rather than an 'ifeval' directive."
